### PR TITLE
Handle divide by zero, qemu testing without display

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ sudo screen /dev/ttyUSB0 115200 cs8
 
 ```
 0x0000000 (  0 MiB) - boot entry point
-0x0000100           - kernel_main function
+0x0001000           - shortExceptionHandlerAt0x1000 function
+0x0001100           - kernelMainAt0x1100 function
 0x8000000 (128 MiB) - top of kernel stack, and bootloader_main function
 0x8800000 (136 MiB) - top of bootloader stack
 ```

--- a/build.zig
+++ b/build.zig
@@ -6,6 +6,7 @@ pub fn build(b: *Builder) !void {
     const mode = b.standardReleaseOptions();
     const want_gdb = b.option(bool, "gdb", "Build for using gdb with qemu") orelse false;
     const want_pty = b.option(bool, "pty", "Create a separate TTY path") orelse false;
+    const want_nodisplay = b.option(bool, "nodisplay", "No display for qemu") orelse false;
 
     const arch = builtin.Arch{ .aarch64 = builtin.Arch.Arm64.v8 };
     const environ = builtin.Abi.eabihf;
@@ -52,6 +53,8 @@ pub fn build(b: *Builder) !void {
         "null",
         "-serial",
         if (want_pty) "pty" else "stdio",
+        "-display",
+        if (want_nodisplay) "none" else "gtk",
     });
     if (want_gdb) {
         try qemu_args.appendSlice([_][]const u8{ "-S", "-s" });

--- a/src/bootloader.ld
+++ b/src/bootloader.ld
@@ -1,7 +1,7 @@
 ENTRY(boot)
 
 SECTIONS {
-    kernel_main = 0x1000; /* Must match value from kernel linker script */
+    kernelMainAt0x1100 = 0x1100; /* Must match value from kernel linker script */
 
     . = 0x8800000; /* Must match debug.bootloader_address */
 
@@ -25,4 +25,3 @@ SECTIONS {
         __bss_end = .;
     }
 }
-

--- a/src/bootloader.zig
+++ b/src/bootloader.zig
@@ -17,7 +17,7 @@ export fn bootloader_main(start_addr: [*]u8, len: usize) linksection(".text.firs
     }
     asm volatile (
         \\mov sp,#0x08000000
-        \\bl kernel_main
+        \\bl kernelMainAt0x1100
     );
     unreachable;
 }

--- a/src/mmio.zig
+++ b/src/mmio.zig
@@ -10,6 +10,10 @@ pub fn read(reg: usize) u32 {
     return @intToPtr(*volatile u32, reg).*;
 }
 
+pub fn dsb() void {
+    asm volatile ("dsb st");
+}
+
 pub fn bigTimeExtraMemoryBarrier() void {
     asm volatile (
         \\ mcr    p15, 0, ip, c7, c5, 0        @ invalidate I cache

--- a/src/qemu-gdb.ld
+++ b/src/qemu-gdb.ld
@@ -6,7 +6,7 @@ SECTIONS {
     .text : ALIGN(4K) {
         KEEP(*(.text.boot))
         __end_init = .;
-        . = 0x100; /* Must match address from bootloader.ld */
+        . = 0x1000; /* Must match address from bootloader.ld */
         KEEP(*(.text.main))
         *(.text)
     }

--- a/src/time.zig
+++ b/src/time.zig
@@ -2,8 +2,7 @@ pub fn init() void {
     cntfrq = asm("mrs %[cntfrq], cntfrq_el0"
         : [cntfrq] "=r" (-> usize));
     if (cntfrq == 0) {
-        cntfrq = 1000*1000;
-        log("cntfrq_el0 register returned 0, assuming {}", cntfrq);
+        cntfrq = 1*1000*1000;
     }
     cntfrq_f32 = @intToFloat(f32, cntfrq);
     update();
@@ -13,6 +12,7 @@ pub fn update() void {
     cntpct = asm("mrs %[cntpct], cntpct_el0"
         : [cntpct] "=r" (-> usize));
     seconds = @intToFloat(f32, cntpct) / cntfrq_f32;
+    milliseconds = cntpct / (cntfrq / 1000);
 }
 
 pub fn sleep(duration: f32) void {
@@ -24,9 +24,8 @@ pub fn sleep(duration: f32) void {
 }
 
 pub var seconds: f32 = undefined;
+pub var milliseconds: usize = undefined;
 
 var cntfrq: usize = undefined;
 var cntfrq_f32: f32 = undefined;
 var cntpct: usize = undefined;
-
-const log = @import("serial.zig").log;

--- a/src/video_core_mailboxes.zig
+++ b/src/video_core_mailboxes.zig
@@ -29,11 +29,12 @@ const Mailbox = packed struct {
         blockWhile(this, isEmpty);
         const response = this.pull();
         if (response != request) {
-            panic(@errorReturnTrace(), "UnexpectedBufferAddressOrChannel");
+            panic(@errorReturnTrace(), "buffer address and channel response was {x} expecting {x}", response, request);
         }
     }
 
     fn push(this: *Mailbox, word: u32) void {
+        mmio.dsb();
         mmio.write(@ptrToInt(&this.push_pull_register), word);
     }
 

--- a/src/video_core_metrics.zig
+++ b/src/video_core_metrics.zig
@@ -1,0 +1,61 @@
+pub const Metrics = struct {
+    board_model: u32,
+    board_revision: u32,
+    firmware_revision: u32,
+    is_qemu: bool,
+    max_temperature: u32,
+    temperature: u32,
+    temperature_id: u32,
+    arm_memory_address: u32,
+    arm_memory_size: u32,
+    vc_memory_address: u32,
+    vc_memory_size: u32,
+    usable_dma_channels_mask: u32,
+
+    pub fn init(self: *Metrics) void {
+        self.temperature_id = 0;
+        callVideoCoreProperties(&[_]PropertiesArg{
+            tag(TAG_GET_FIRMWARE_REVISION, 4),
+            out(&self.firmware_revision),
+            tag(TAG_GET_BOARD_MODEL, 4),
+            out(&self.board_model),
+            tag(TAG_GET_BOARD_REVISION, 4),
+            out(&self.board_revision),
+            tag(TAG_GET_MAX_TEMPERATURE, 8),
+            set(&self.temperature_id),
+            out(&self.max_temperature),
+            tag(TAG_GET_ARM_MEMORY, 8),
+            out(&self.arm_memory_address),
+            out(&self.arm_memory_size),
+            tag(TAG_GET_VC_MEMORY, 8),
+            out(&self.vc_memory_address),
+            out(&self.vc_memory_size),
+            tag(TAG_GET_USABLE_DMA_CHANNELS_MASK, 4),
+            out(&self.usable_dma_channels_mask),
+            lastTagSentinel(),
+        });
+        self.is_qemu = self.board_model == 0xaaaaaaaa;
+        self.update();
+    }
+
+    pub fn update(m: *Metrics) void {
+        callVideoCoreProperties(&[_]PropertiesArg{
+            tag(TAG_GET_TEMPERATURE, 8),
+            set(&m.temperature_id),
+            out(&m.temperature),
+            lastTagSentinel(),
+        });
+    }
+};
+
+const TAG_GET_ARM_MEMORY = 0x10005;
+const TAG_GET_BOARD_MODEL = 0x10001;
+const TAG_GET_BOARD_REVISION = 0x10002;
+const TAG_GET_FIRMWARE_REVISION = 0x00001;
+const TAG_GET_MAX_TEMPERATURE = 0x3000A;
+const TAG_GET_TEMPERATURE = 0x30006;
+const TAG_GET_USABLE_DMA_CHANNELS_MASK = 0x60001;
+const TAG_GET_VC_MEMORY = 0x10006;
+
+const panic = @import("debug.zig").panic;
+use @import("video_core_properties.zig");

--- a/src/video_core_properties.zig
+++ b/src/video_core_properties.zig
@@ -3,7 +3,7 @@ pub fn callVideoCoreProperties(args: []PropertiesArg) void {
         panic(@errorReturnTrace(), "video core mailbox buffer missing last tag sentinel");
     }
 
-    var words: [512]u32 align(16) = undefined;
+    var words: [1024]u32 align(16) = undefined;
     var buf = SliceIterator.of(u32).init(&words);
 
     var buffer_length_in_bytes: u32 = 0;
@@ -123,8 +123,7 @@ fn check(buf: *SliceIterator.of(u32), word: u32) void {
     }
 }
 
-const assert = std.debug.assert;
-//const log = @import("serial.zig").log;
+const log = @import("serial.zig").log;
 const mailboxes = @import("video_core_mailboxes.zig").mailboxes;
 const panic = @import("debug.zig").panic;
 const SliceIterator = @import("slice_iterator.zig");


### PR DESCRIPTION
added main.zig/fn panic to capture division by zero
added zig build qemu -Dnodisplay to test on command line without graphics display
improved pixels per second from 45k to 70k by writing whole 32-bit rgba word at a time
scattered refactorings